### PR TITLE
Add es6-promise polyfill to fix Promises in IE

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -1,4 +1,5 @@
 require('whatwg-fetch');
+require('es6-promise').polyfill();
 
 var DesktopPlatform = require('./DesktopPlatform');
 var CardboardPlatform = require('./CardboardPlatform');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ var brfs = require('brfs');
 var tsify = require('tsify');
 
 var config = {
-  external: ['underscore', 'whatwg-fetch', 'buffer', 'three'],
+  external: ['underscore', 'whatwg-fetch', 'buffer', 'three', 'es6-promise'],
   watch: false,
   sourceMaps: true
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "three": "^0.71.0",
     "tsify": "^0.11.2",
     "underscore": "^1.8.3",
-    "whatwg-fetch": "^0.9.0"
+    "whatwg-fetch": "^0.9.0",
+    "es6-promise": "^1.3.10"
   },
   "devDependencies": {
     "brfs": "^1.4.0",


### PR DESCRIPTION
I gave this a test in IE11 and it was breaking on [Game.ts line 58](https://github.com/cjdell/web-blocks/blob/master/app/Game.ts#L58). It was throwing: `'Promise' is undefined`

I added [ES6-promise](https://github.com/jakearchibald/es6-promise) polyfill to fix it.

I have tested it on IE11 and it works now.
