### PR TITLE
updated jump to fire on keydown instead of keyup

### DIFF
--- a/app/DesktopViewPoint.ts
+++ b/app/DesktopViewPoint.ts
@@ -71,6 +71,8 @@ export default class DesktopViewPoint {
     if (event.keyCode === 37) this.turn.x = 1;      // Left Arrow (Turn Left)
     if (event.keyCode === 39) this.turn.x = -1;       // Right Arrow (Turn Right)
 
+    if (event.keyCode === 32 && !this.workerInterface.jumping) this.workerInterface.jump();
+
     this.workerInterface.move(this.movement, this.turn);
   }
 
@@ -90,7 +92,7 @@ export default class DesktopViewPoint {
     if (event.keyCode === 37) this.turn.x = 0;       // Left Arrow (Turn Left)
     if (event.keyCode === 39) this.turn.x = 0;       // Right Arrow (Turn Right)
 
-    if (event.keyCode === 32) this.workerInterface.jump();
+    if (event.keyCode === 32) this.workerInterface.jumping = false;
 
     this.workerInterface.move(this.movement, this.turn);
   }

--- a/app/WorkerInterface.ts
+++ b/app/WorkerInterface.ts
@@ -12,6 +12,7 @@ export default class WorkerInterface {
   changeListener: Function = null;
   playerPositionListener: ((position: THREE.Vector3) => void);
   lastId = 0;
+  jumping:boolean = false;
 
   constructor() {
     this.geoWorker = new Worker('build/worker.js');
@@ -103,6 +104,7 @@ export default class WorkerInterface {
   }
 
   jump() {
+    this.jumping = true;
     return this.invoke<Object>('action', { action: 'jump' });
   }
 


### PR DESCRIPTION
I think this feels much more natural. It significantly reduces the delay of the jump too. I also kept the original functionality (repeatedly hitting space will go higher and higher, but you cannot hold it down).
