### PR TITLE
Correct behavior on window swap, right-click ready to use

### DIFF
--- a/app/Interaction.ts
+++ b/app/Interaction.ts
@@ -40,6 +40,7 @@ export default class Interaction {
       viewPort.addEventListener('mousedown', (e) => this.mouseDown(e), false);
       viewPort.addEventListener('mousemove', (e) => this.mouseMove(e), false);
       viewPort.addEventListener('mouseup', (e) => this.mouseUp(e), false);
+      viewPort.addEventListener('contextmenu', (e) => this.mouseUp(e), false);
 
       document.addEventListener('keypress', (e) => this.keyPress(e), false);
     }
@@ -52,6 +53,10 @@ export default class Interaction {
   }
 
   private mouseDown(event: any) {
+    if (event.type == 'contextmenu' || event.button == 2) {
+      event.preventDefault();
+      return;
+    }
     this.down = true;
   }
 
@@ -72,6 +77,12 @@ export default class Interaction {
 
     const pos = this.getBlockPositionOfMouse();
     if (!pos) return;
+
+    // If we right-click
+    if (event.type == 'contextmenu' || event.button == 2) {
+      event.preventDefault();
+      return;
+    }
 
     if (!this.tool) {
       this.tool = this.getTool();


### PR DESCRIPTION
Unfortunately it appears that we can't automatically resume mouse-lock state when hiding and showing the browser tab / window, but I did make a few tweaks to ensure state properly reset on hide. Right-click now does not show the context menu on the viewport. We can easily extend this to the entire window, but I thought it might be useful to be able to easily "inspect", as this is a teaching tool, in the right-side menu. I did this so that in the future the functionality could be added to right-click, like delete blocks when block tool is selected.
